### PR TITLE
Add logging service participation posture

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,6 +295,7 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 [[package]]
 name = "constitute-fabric"
 version = "0.1.0"
+source = "git+https://github.com/Aux0x7F/constitute-fabric?branch=main#433f54397fdee6f5619f9de408b4a307143a0191"
 dependencies = [
  "anyhow",
  "constitute-protocol",
@@ -329,6 +330,7 @@ dependencies = [
 [[package]]
 name = "constitute-protocol"
 version = "0.1.0"
+source = "git+https://github.com/Aux0x7F/constitute-protocol?branch=main#e0db94216f0a57bf427086f225156db4625717cd"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,12 +293,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "constitute-fabric"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "constitute-protocol",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "constitute-logging"
 version = "0.1.0"
 dependencies = [
  "anyhow",
  "axum",
  "clap",
+ "constitute-fabric",
  "constitute-protocol",
  "futures-util",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2024"
 anyhow = "1"
 axum = { version = "0.8", features = ["ws"] }
 clap = { version = "4.5", features = ["derive", "env"] }
-constitute-fabric = { path = "../constitute-fabric" }
-constitute-protocol = { path = "../constitute-protocol" }
+constitute-fabric = { git = "https://github.com/Aux0x7F/constitute-fabric", branch = "main" }
+constitute-protocol = { git = "https://github.com/Aux0x7F/constitute-protocol", branch = "main" }
 futures-util = "0.3"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 rusqlite = { version = "0.32", features = ["bundled"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 anyhow = "1"
 axum = { version = "0.8", features = ["ws"] }
 clap = { version = "4.5", features = ["derive", "env"] }
+constitute-fabric = { path = "../constitute-fabric" }
 constitute-protocol = { path = "../constitute-protocol" }
 futures-util = "0.3"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }

--- a/src/edge_client.rs
+++ b/src/edge_client.rs
@@ -1,10 +1,10 @@
 // domain-owned-vocabulary: logging.edge.reject swarm.edge.claims
 use anyhow::{Context, Result};
+use constitute_fabric::{HostFabricMemberContributionSpec, build_host_fabric_member_contribution};
 use constitute_protocol::{
-    CAPABILITY_SWARM_EDGE_ATTACH, SWARM_EDGE_WIRE_ACCEPT, SWARM_EDGE_WIRE_HELLO,
-    SWARM_EDGE_WIRE_RESUME, SWARM_FRAME_VERSION, SWARM_WIRE_FRAME,
-    FABRIC_MEMBER_CONTRIBUTION_RUNNING, FABRIC_MEMBER_ROLE_LOGGING_PROCESSOR,
-    HostFabricMemberContribution, RECORD_HOST_FABRIC_MEMBER_CONTRIBUTION, SwarmAck,
+    CAPABILITY_SWARM_EDGE_ATTACH, FABRIC_MEMBER_CONTRIBUTION_RUNNING,
+    FABRIC_MEMBER_ROLE_LOGGING_PROCESSOR, HostFabricMemberContribution, SWARM_EDGE_WIRE_ACCEPT,
+    SWARM_EDGE_WIRE_HELLO, SWARM_EDGE_WIRE_RESUME, SWARM_FRAME_VERSION, SWARM_WIRE_FRAME, SwarmAck,
     SwarmEdgeAccept, SwarmEdgeHello, SwarmFrame, SwarmFrameBody, SwarmFrameKind, ZoneScope,
     seal_envelope, swarm_frame_id, validate_host_fabric_member_contribution,
     validate_swarm_edge_hello, validate_swarm_frame,
@@ -61,7 +61,8 @@ enum ServiceWireMessage<'a> {
 
 pub fn build_hello(config: &SwarmEdgeClientConfig, now: u64) -> SwarmEdgeHello {
     let service_ref = format!("service:logging:{}", config.service_pk.trim());
-    let fabric_contribution = logging_host_fabric_contribution(config, &service_ref, now);
+    let fabric_contribution = logging_host_fabric_contribution(config, &service_ref, now)
+        .expect("logging host-fabric contribution builds");
     let fabric_contribution_ref = fabric_contribution.contribution_id.clone();
     validate_host_fabric_member_contribution(&fabric_contribution)
         .expect("logging host-fabric contribution is valid");
@@ -130,12 +131,11 @@ fn logging_host_fabric_contribution(
     config: &SwarmEdgeClientConfig,
     service_ref: &str,
     now: u64,
-) -> HostFabricMemberContribution {
+) -> Result<HostFabricMemberContribution> {
     let zone_ref = format!("discovery:{}", config.zone_id.trim());
     let fabric_ref = format!("host-fabric:{}", config.zone_id.trim());
     let evidence_ref = format!("swarm.edge.hello:logging:{now}");
-    HostFabricMemberContribution {
-        kind: Some(RECORD_HOST_FABRIC_MEMBER_CONTRIBUTION.to_string()),
+    let contribution = build_host_fabric_member_contribution(HostFabricMemberContributionSpec {
         contribution_id: format!("hostFabric:logging:{}", config.service_pk.trim()),
         fabric_ref,
         host_ref: zone_ref.clone(),
@@ -149,7 +149,10 @@ fn logging_host_fabric_contribution(
             .map(|value| value.to_string())
             .collect(),
         grant_refs: Vec::new(),
-        input_refs: LOGGING_CHANNELS.iter().map(|value| value.to_string()).collect(),
+        input_refs: LOGGING_CHANNELS
+            .iter()
+            .map(|value| value.to_string())
+            .collect(),
         output_refs: vec![service_ref.to_string()],
         evidence_refs: vec![evidence_ref],
         lifecycle_plan_refs: Vec::new(),
@@ -163,7 +166,10 @@ fn logging_host_fabric_contribution(
         }),
         observed_at: now,
         expires_at: Some(now + 60_000),
-    }
+    })?;
+    validate_host_fabric_member_contribution(&contribution)
+        .expect("logging host-fabric contribution is valid");
+    Ok(contribution)
 }
 
 pub fn validate_hello(hello: &SwarmEdgeHello) -> Result<()> {

--- a/src/edge_client.rs
+++ b/src/edge_client.rs
@@ -2,9 +2,12 @@
 use anyhow::{Context, Result};
 use constitute_protocol::{
     CAPABILITY_SWARM_EDGE_ATTACH, SWARM_EDGE_WIRE_ACCEPT, SWARM_EDGE_WIRE_HELLO,
-    SWARM_EDGE_WIRE_RESUME, SWARM_FRAME_VERSION, SWARM_WIRE_FRAME, SwarmAck, SwarmEdgeAccept,
-    SwarmEdgeHello, SwarmFrame, SwarmFrameBody, SwarmFrameKind, ZoneScope, seal_envelope,
-    swarm_frame_id, validate_swarm_edge_hello, validate_swarm_frame,
+    SWARM_EDGE_WIRE_RESUME, SWARM_FRAME_VERSION, SWARM_WIRE_FRAME,
+    FABRIC_MEMBER_CONTRIBUTION_RUNNING, FABRIC_MEMBER_ROLE_LOGGING_PROCESSOR,
+    HostFabricMemberContribution, RECORD_HOST_FABRIC_MEMBER_CONTRIBUTION, SwarmAck,
+    SwarmEdgeAccept, SwarmEdgeHello, SwarmFrame, SwarmFrameBody, SwarmFrameKind, ZoneScope,
+    seal_envelope, swarm_frame_id, validate_host_fabric_member_contribution,
+    validate_swarm_edge_hello, validate_swarm_frame,
 };
 use futures_util::{SinkExt, StreamExt};
 use serde::{Deserialize, Serialize};
@@ -58,7 +61,15 @@ enum ServiceWireMessage<'a> {
 
 pub fn build_hello(config: &SwarmEdgeClientConfig, now: u64) -> SwarmEdgeHello {
     let service_ref = format!("service:logging:{}", config.service_pk.trim());
-    let promise_refs = vec![service_ref.clone(), config.service_pk.trim().to_string()];
+    let fabric_contribution = logging_host_fabric_contribution(config, &service_ref, now);
+    let fabric_contribution_ref = fabric_contribution.contribution_id.clone();
+    validate_host_fabric_member_contribution(&fabric_contribution)
+        .expect("logging host-fabric contribution is valid");
+    let promise_refs = vec![
+        service_ref.clone(),
+        config.service_pk.trim().to_string(),
+        fabric_contribution_ref.clone(),
+    ];
     SwarmEdgeHello {
         member_kind: "service".to_string(),
         member_ref: config.member_ref.clone(),
@@ -95,6 +106,8 @@ pub fn build_hello(config: &SwarmEdgeClientConfig, now: u64) -> SwarmEdgeHello {
                     "memberRef": config.member_ref.clone(),
                     "serviceRef": service_ref,
                     "servicePk": config.service_pk.clone(),
+                    "hostFabricMemberContributionRef": fabric_contribution_ref,
+                    "hostFabricMemberContribution": fabric_contribution,
                     "capabilityRefs": LOGGING_EDGE_CAPABILITIES,
                     "channelRefs": LOGGING_CHANNELS,
                     "promiseRefs": promise_refs,
@@ -110,6 +123,46 @@ pub fn build_hello(config: &SwarmEdgeClientConfig, now: u64) -> SwarmEdgeHello {
             payload: None,
             signature: None,
         },
+    }
+}
+
+fn logging_host_fabric_contribution(
+    config: &SwarmEdgeClientConfig,
+    service_ref: &str,
+    now: u64,
+) -> HostFabricMemberContribution {
+    let zone_ref = format!("discovery:{}", config.zone_id.trim());
+    let fabric_ref = format!("host-fabric:{}", config.zone_id.trim());
+    let evidence_ref = format!("swarm.edge.hello:logging:{now}");
+    HostFabricMemberContribution {
+        kind: Some(RECORD_HOST_FABRIC_MEMBER_CONTRIBUTION.to_string()),
+        contribution_id: format!("hostFabric:logging:{}", config.service_pk.trim()),
+        fabric_ref,
+        host_ref: zone_ref.clone(),
+        member_ref: config.member_ref.clone(),
+        role: FABRIC_MEMBER_ROLE_LOGGING_PROCESSOR.to_string(),
+        state: FABRIC_MEMBER_CONTRIBUTION_RUNNING.to_string(),
+        contract_ref: service_ref.to_string(),
+        subject_ref: service_ref.to_string(),
+        capability_refs: LOGGING_EDGE_CAPABILITIES
+            .iter()
+            .map(|value| value.to_string())
+            .collect(),
+        grant_refs: Vec::new(),
+        input_refs: LOGGING_CHANNELS.iter().map(|value| value.to_string()).collect(),
+        output_refs: vec![service_ref.to_string()],
+        evidence_refs: vec![evidence_ref],
+        lifecycle_plan_refs: Vec::new(),
+        release_refs: Vec::new(),
+        resource_posture: None,
+        blocked_reasons: Vec::new(),
+        safe_facts: json!({
+            "service": "logging",
+            "role": FABRIC_MEMBER_ROLE_LOGGING_PROCESSOR,
+            "zoneRef": zone_ref,
+        }),
+        observed_at: now,
+        expires_at: Some(now + 60_000),
     }
 }
 
@@ -778,6 +831,11 @@ mod tests {
                 .contains(&format!("service:logging:{service_pk}"))
         );
         assert!(hello.promise_refs.contains(&service_pk));
+        assert!(
+            hello
+                .promise_refs
+                .contains(&format!("hostFabric:logging:{service_pk}"))
+        );
 
         let wire =
             serde_json::to_value(ServiceWireMessage::Hello { hello: &hello }).expect("wire json");


### PR DESCRIPTION
Adds logging service participation posture aligned with shared contract target and materialization records.\n\nProof: local native, browser, convergence, affected, and aggregate checks passed.