### PR TITLE
feat: prove routed event fabric processing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,7 +295,7 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 [[package]]
 name = "constitute-fabric"
 version = "0.1.0"
-source = "git+https://github.com/Aux0x7F/constitute-fabric?branch=0x%2Ffabric-transition%2Ftopology-execution#892e6be718bf7503b42245fc4a9fa2da2106be3d"
+source = "git+https://github.com/Aux0x7F/constitute-fabric?branch=0x%2Ffabric-transition%2Ftopology-execution#2e3cf58930686e3cd0d205ecefb022e56e115f27"
 dependencies = [
  "anyhow",
  "constitute-protocol",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,7 +295,7 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 [[package]]
 name = "constitute-fabric"
 version = "0.1.0"
-source = "git+https://github.com/Aux0x7F/constitute-fabric?branch=0x%2Ffabric-transition%2Ftopology-execution#148566766163dfe5c6d18d5257213775f6b7418e"
+source = "git+https://github.com/Aux0x7F/constitute-fabric?branch=0x%2Ffabric-transition%2Ftopology-execution#ed9e35a98175d193898904d45c3475f02047db53"
 dependencies = [
  "anyhow",
  "constitute-protocol",
@@ -330,7 +330,7 @@ dependencies = [
 [[package]]
 name = "constitute-protocol"
 version = "0.1.0"
-source = "git+https://github.com/Aux0x7F/constitute-protocol?branch=0x%2Ffabric-transition%2Ftopology-execution#7f7ecb1b628cfa05b396f23b480f741fe5b1ce43"
+source = "git+https://github.com/Aux0x7F/constitute-protocol?branch=0x%2Ffabric-transition%2Ftopology-execution#59780429db834875e274cad07f7c467737a86dd0"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,7 +295,7 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 [[package]]
 name = "constitute-fabric"
 version = "0.1.0"
-source = "git+https://github.com/Aux0x7F/constitute-fabric?branch=0x%2Ffabric-transition%2Fcarrier-edge#7842aa15617cb74e73e476873807e50b3e27a253"
+source = "git+https://github.com/Aux0x7F/constitute-fabric?branch=0x%2Ffabric-transition%2Ftopology-execution#a87c9ac509d15a60cc448efb7478e15de569fe0b"
 dependencies = [
  "anyhow",
  "constitute-protocol",
@@ -330,7 +330,7 @@ dependencies = [
 [[package]]
 name = "constitute-protocol"
 version = "0.1.0"
-source = "git+https://github.com/Aux0x7F/constitute-protocol?branch=0x%2Ffabric-transition%2Fcarrier-edge#aa2007fea9d77dbfdcf99243c12db06275c46db2"
+source = "git+https://github.com/Aux0x7F/constitute-protocol?branch=0x%2Ffabric-transition%2Ftopology-execution#4368543f230f77edc69f91d4cccb539706c2e8fa"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,7 +295,7 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 [[package]]
 name = "constitute-fabric"
 version = "0.1.0"
-source = "git+https://github.com/Aux0x7F/constitute-fabric?branch=main#436dc9df1c40f74d59d75af460a0f44cd6cd61ba"
+source = "git+https://github.com/Aux0x7F/constitute-fabric?branch=0x%2Fhardening-posture#6295f4028c774e375f2e783305784dc2dbc7adad"
 dependencies = [
  "anyhow",
  "constitute-protocol",
@@ -330,7 +330,7 @@ dependencies = [
 [[package]]
 name = "constitute-protocol"
 version = "0.1.0"
-source = "git+https://github.com/Aux0x7F/constitute-protocol?branch=main#86bcf9988d79057ad3d567ce805ba22c7dcc094f"
+source = "git+https://github.com/Aux0x7F/constitute-protocol?branch=0x%2Fhardening-posture#a27705fa95e9b162761b16696ffb0efbdf6e3377"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,10 +295,10 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 [[package]]
 name = "constitute-fabric"
 version = "0.1.0"
-source = "git+https://github.com/Aux0x7F/constitute-fabric?branch=0x%2Ffabric-transition%2Ftopology-execution#6c440a99c56d202362bbfd639561062c12627a49"
+source = "git+https://github.com/Aux0x7F/constitute-fabric?branch=0x%2Ffabric-transition%2Fcarrier-edge#6c440a99c56d202362bbfd639561062c12627a49"
 dependencies = [
  "anyhow",
- "constitute-protocol",
+ "constitute-protocol 0.1.0 (git+https://github.com/Aux0x7F/constitute-protocol?branch=0x%2Ffabric-transition%2Ftopology-execution)",
  "serde",
  "serde_json",
 ]
@@ -311,7 +311,7 @@ dependencies = [
  "axum",
  "clap",
  "constitute-fabric",
- "constitute-protocol",
+ "constitute-protocol 0.1.0 (git+https://github.com/Aux0x7F/constitute-protocol?branch=0x%2Ffabric-transition%2Fcarrier-edge)",
  "futures-util",
  "reqwest",
  "rusqlite",
@@ -325,6 +325,23 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "urlencoding",
+]
+
+[[package]]
+name = "constitute-protocol"
+version = "0.1.0"
+source = "git+https://github.com/Aux0x7F/constitute-protocol?branch=0x%2Ffabric-transition%2Fcarrier-edge#da32aff26e6841444a6a7f16e9655e6e33a48e0c"
+dependencies = [
+ "anyhow",
+ "base64",
+ "chacha20poly1305",
+ "hex",
+ "hkdf",
+ "rand 0.8.6",
+ "secp256k1",
+ "serde",
+ "serde_json",
+ "sha2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -330,7 +330,7 @@ dependencies = [
 [[package]]
 name = "constitute-protocol"
 version = "0.1.0"
-source = "git+https://github.com/Aux0x7F/constitute-protocol?branch=0x%2Ffabric-transition%2Ftopology-execution#354b41785f0bc3cb358a837e408b2380cbcfc2ae"
+source = "git+https://github.com/Aux0x7F/constitute-protocol?branch=0x%2Ffabric-transition%2Ftopology-execution#7f7ecb1b628cfa05b396f23b480f741fe5b1ce43"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,7 +295,6 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 [[package]]
 name = "constitute-fabric"
 version = "0.1.0"
-source = "git+https://github.com/Aux0x7F/constitute-fabric?branch=0x%2Ffabric-transition%2Ftopology-execution#2e3cf58930686e3cd0d205ecefb022e56e115f27"
 dependencies = [
  "anyhow",
  "constitute-protocol",
@@ -330,7 +329,6 @@ dependencies = [
 [[package]]
 name = "constitute-protocol"
 version = "0.1.0"
-source = "git+https://github.com/Aux0x7F/constitute-protocol?branch=0x%2Ffabric-transition%2Ftopology-execution#59780429db834875e274cad07f7c467737a86dd0"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,7 +295,7 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 [[package]]
 name = "constitute-fabric"
 version = "0.1.0"
-source = "git+https://github.com/Aux0x7F/constitute-fabric?branch=main#8e0a14a49bd06d32f8b0b37d2d6705fcc561980b"
+source = "git+https://github.com/Aux0x7F/constitute-fabric?branch=0x%2Ffabric-transition%2Ftopology-execution#6c440a99c56d202362bbfd639561062c12627a49"
 dependencies = [
  "anyhow",
  "constitute-protocol",
@@ -330,7 +330,7 @@ dependencies = [
 [[package]]
 name = "constitute-protocol"
 version = "0.1.0"
-source = "git+https://github.com/Aux0x7F/constitute-protocol?branch=main#64ce682719ed76cf93cfb084cb4499cbe0499898"
+source = "git+https://github.com/Aux0x7F/constitute-protocol?branch=0x%2Ffabric-transition%2Ftopology-execution#da32aff26e6841444a6a7f16e9655e6e33a48e0c"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,7 +295,7 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 [[package]]
 name = "constitute-fabric"
 version = "0.1.0"
-source = "git+https://github.com/Aux0x7F/constitute-fabric?branch=0x%2Ffabric-transition%2Ftopology-execution#ed9e35a98175d193898904d45c3475f02047db53"
+source = "git+https://github.com/Aux0x7F/constitute-fabric?branch=0x%2Ffabric-transition%2Ftopology-execution#892e6be718bf7503b42245fc4a9fa2da2106be3d"
 dependencies = [
  "anyhow",
  "constitute-protocol",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,7 +295,7 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 [[package]]
 name = "constitute-fabric"
 version = "0.1.0"
-source = "git+https://github.com/Aux0x7F/constitute-fabric?branch=0x%2Ffabric-transition%2Ftopology-execution#a87c9ac509d15a60cc448efb7478e15de569fe0b"
+source = "git+https://github.com/Aux0x7F/constitute-fabric?branch=0x%2Ffabric-transition%2Ftopology-execution#148566766163dfe5c6d18d5257213775f6b7418e"
 dependencies = [
  "anyhow",
  "constitute-protocol",
@@ -330,7 +330,7 @@ dependencies = [
 [[package]]
 name = "constitute-protocol"
 version = "0.1.0"
-source = "git+https://github.com/Aux0x7F/constitute-protocol?branch=0x%2Ffabric-transition%2Ftopology-execution#4368543f230f77edc69f91d4cccb539706c2e8fa"
+source = "git+https://github.com/Aux0x7F/constitute-protocol?branch=0x%2Ffabric-transition%2Ftopology-execution#354b41785f0bc3cb358a837e408b2380cbcfc2ae"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,7 +295,7 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 [[package]]
 name = "constitute-fabric"
 version = "0.1.0"
-source = "git+https://github.com/Aux0x7F/constitute-fabric?branch=0x%2Fhardening-posture#6295f4028c774e375f2e783305784dc2dbc7adad"
+source = "git+https://github.com/Aux0x7F/constitute-fabric?branch=main#8e0a14a49bd06d32f8b0b37d2d6705fcc561980b"
 dependencies = [
  "anyhow",
  "constitute-protocol",
@@ -330,7 +330,7 @@ dependencies = [
 [[package]]
 name = "constitute-protocol"
 version = "0.1.0"
-source = "git+https://github.com/Aux0x7F/constitute-protocol?branch=0x%2Fhardening-posture#a27705fa95e9b162761b16696ffb0efbdf6e3377"
+source = "git+https://github.com/Aux0x7F/constitute-protocol?branch=main#64ce682719ed76cf93cfb084cb4499cbe0499898"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,7 +295,7 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 [[package]]
 name = "constitute-fabric"
 version = "0.1.0"
-source = "git+https://github.com/Aux0x7F/constitute-fabric?branch=0x%2Ffabric-transition%2Fcarrier-edge#5b2d1700ca6e4d8a7ec6baad35786a8710cab77c"
+source = "git+https://github.com/Aux0x7F/constitute-fabric?branch=0x%2Ffabric-transition%2Fcarrier-edge#7842aa15617cb74e73e476873807e50b3e27a253"
 dependencies = [
  "anyhow",
  "constitute-protocol",
@@ -330,7 +330,7 @@ dependencies = [
 [[package]]
 name = "constitute-protocol"
 version = "0.1.0"
-source = "git+https://github.com/Aux0x7F/constitute-protocol?branch=0x%2Ffabric-transition%2Fcarrier-edge#da32aff26e6841444a6a7f16e9655e6e33a48e0c"
+source = "git+https://github.com/Aux0x7F/constitute-protocol?branch=0x%2Ffabric-transition%2Fcarrier-edge#aa2007fea9d77dbfdcf99243c12db06275c46db2"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,10 +295,10 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 [[package]]
 name = "constitute-fabric"
 version = "0.1.0"
-source = "git+https://github.com/Aux0x7F/constitute-fabric?branch=0x%2Ffabric-transition%2Fcarrier-edge#6c440a99c56d202362bbfd639561062c12627a49"
+source = "git+https://github.com/Aux0x7F/constitute-fabric?branch=0x%2Ffabric-transition%2Fcarrier-edge#5b2d1700ca6e4d8a7ec6baad35786a8710cab77c"
 dependencies = [
  "anyhow",
- "constitute-protocol 0.1.0 (git+https://github.com/Aux0x7F/constitute-protocol?branch=0x%2Ffabric-transition%2Ftopology-execution)",
+ "constitute-protocol",
  "serde",
  "serde_json",
 ]
@@ -311,7 +311,7 @@ dependencies = [
  "axum",
  "clap",
  "constitute-fabric",
- "constitute-protocol 0.1.0 (git+https://github.com/Aux0x7F/constitute-protocol?branch=0x%2Ffabric-transition%2Fcarrier-edge)",
+ "constitute-protocol",
  "futures-util",
  "reqwest",
  "rusqlite",
@@ -331,23 +331,6 @@ dependencies = [
 name = "constitute-protocol"
 version = "0.1.0"
 source = "git+https://github.com/Aux0x7F/constitute-protocol?branch=0x%2Ffabric-transition%2Fcarrier-edge#da32aff26e6841444a6a7f16e9655e6e33a48e0c"
-dependencies = [
- "anyhow",
- "base64",
- "chacha20poly1305",
- "hex",
- "hkdf",
- "rand 0.8.6",
- "secp256k1",
- "serde",
- "serde_json",
- "sha2",
-]
-
-[[package]]
-name = "constitute-protocol"
-version = "0.1.0"
-source = "git+https://github.com/Aux0x7F/constitute-protocol?branch=0x%2Ffabric-transition%2Ftopology-execution#da32aff26e6841444a6a7f16e9655e6e33a48e0c"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2024"
 anyhow = "1"
 axum = { version = "0.8", features = ["ws"] }
 clap = { version = "4.5", features = ["derive", "env"] }
-constitute-fabric = { git = "https://github.com/Aux0x7F/constitute-fabric", branch = "0x/fabric-transition/topology-execution" }
-constitute-protocol = { git = "https://github.com/Aux0x7F/constitute-protocol", branch = "0x/fabric-transition/topology-execution" }
+constitute-fabric = { path = "../constitute-fabric" }
+constitute-protocol = { path = "../constitute-protocol" }
 futures-util = "0.3"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 rusqlite = { version = "0.32", features = ["bundled"] }
@@ -24,3 +24,6 @@ urlencoding = "2"
 [dev-dependencies]
 tempfile = "3"
 tower = { version = "0.5", features = ["util"] }
+
+[patch."https://github.com/Aux0x7F/constitute-protocol"]
+constitute-protocol = { path = "../constitute-protocol" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2024"
 anyhow = "1"
 axum = { version = "0.8", features = ["ws"] }
 clap = { version = "4.5", features = ["derive", "env"] }
-constitute-fabric = { git = "https://github.com/Aux0x7F/constitute-fabric", branch = "0x/fabric-transition/topology-execution" }
-constitute-protocol = { git = "https://github.com/Aux0x7F/constitute-protocol", branch = "0x/fabric-transition/topology-execution" }
+constitute-fabric = { git = "https://github.com/Aux0x7F/constitute-fabric", branch = "0x/fabric-transition/carrier-edge" }
+constitute-protocol = { git = "https://github.com/Aux0x7F/constitute-protocol", branch = "0x/fabric-transition/carrier-edge" }
 futures-util = "0.3"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 rusqlite = { version = "0.32", features = ["bundled"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2024"
 anyhow = "1"
 axum = { version = "0.8", features = ["ws"] }
 clap = { version = "4.5", features = ["derive", "env"] }
-constitute-fabric = { git = "https://github.com/Aux0x7F/constitute-fabric", branch = "0x/fabric-transition/carrier-edge" }
-constitute-protocol = { git = "https://github.com/Aux0x7F/constitute-protocol", branch = "0x/fabric-transition/carrier-edge" }
+constitute-fabric = { git = "https://github.com/Aux0x7F/constitute-fabric", branch = "0x/fabric-transition/topology-execution" }
+constitute-protocol = { git = "https://github.com/Aux0x7F/constitute-protocol", branch = "0x/fabric-transition/topology-execution" }
 futures-util = "0.3"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 rusqlite = { version = "0.32", features = ["bundled"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2024"
 anyhow = "1"
 axum = { version = "0.8", features = ["ws"] }
 clap = { version = "4.5", features = ["derive", "env"] }
-constitute-fabric = { git = "https://github.com/Aux0x7F/constitute-fabric", branch = "main" }
-constitute-protocol = { git = "https://github.com/Aux0x7F/constitute-protocol", branch = "main" }
+constitute-fabric = { git = "https://github.com/Aux0x7F/constitute-fabric", branch = "0x/hardening-posture" }
+constitute-protocol = { git = "https://github.com/Aux0x7F/constitute-protocol", branch = "0x/hardening-posture" }
 futures-util = "0.3"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 rusqlite = { version = "0.32", features = ["bundled"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2024"
 anyhow = "1"
 axum = { version = "0.8", features = ["ws"] }
 clap = { version = "4.5", features = ["derive", "env"] }
-constitute-fabric = { git = "https://github.com/Aux0x7F/constitute-fabric", branch = "main" }
-constitute-protocol = { git = "https://github.com/Aux0x7F/constitute-protocol", branch = "main" }
+constitute-fabric = { git = "https://github.com/Aux0x7F/constitute-fabric", branch = "0x/fabric-transition/topology-execution" }
+constitute-protocol = { git = "https://github.com/Aux0x7F/constitute-protocol", branch = "0x/fabric-transition/topology-execution" }
 futures-util = "0.3"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 rusqlite = { version = "0.32", features = ["bundled"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2024"
 anyhow = "1"
 axum = { version = "0.8", features = ["ws"] }
 clap = { version = "4.5", features = ["derive", "env"] }
-constitute-fabric = { git = "https://github.com/Aux0x7F/constitute-fabric", branch = "0x/hardening-posture" }
-constitute-protocol = { git = "https://github.com/Aux0x7F/constitute-protocol", branch = "0x/hardening-posture" }
+constitute-fabric = { git = "https://github.com/Aux0x7F/constitute-fabric", branch = "main" }
+constitute-protocol = { git = "https://github.com/Aux0x7F/constitute-protocol", branch = "main" }
 futures-util = "0.3"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 rusqlite = { version = "0.32", features = ["bundled"] }

--- a/src/api.rs
+++ b/src/api.rs
@@ -10,8 +10,10 @@ use constitute_protocol::{
     CAPABILITY_PROJECTION_OBSERVE, CaacEnvelope, ConsumerFloor, EncryptedDetailRef,
     EventFabricAccessClassRecord, EventFabricProcessorContractRecord,
     LOG_EVIDENCE_DETAIL_CUSTODY_ENCRYPTED_DETAIL_REF, LOG_EVIDENCE_PROFILE_EVENT_CYBERSEC_AUDIT,
-    LOG_EVIDENCE_PROFILE_EVENT_MEDIA_PATH, LOG_EVIDENCE_PROFILE_EVENT_RUNTIME_DIAGNOSTIC,
-    LOG_EVIDENCE_PROFILE_EVENT_SERVICE_EVENT, LOG_EVIDENCE_PROFILE_EVENT_STORAGE_ACCESS,
+    LOG_EVIDENCE_PROFILE_EVENT_EVIDENCE_REQUEST, LOG_EVIDENCE_PROFILE_EVENT_HOST_SECURITY,
+    LOG_EVIDENCE_PROFILE_EVENT_MEDIA_PATH, LOG_EVIDENCE_PROFILE_EVENT_NETWORK_EXPOSURE,
+    LOG_EVIDENCE_PROFILE_EVENT_RUNTIME_DIAGNOSTIC, LOG_EVIDENCE_PROFILE_EVENT_SERVICE_EVENT,
+    LOG_EVIDENCE_PROFILE_EVENT_SERVICE_HARDENING, LOG_EVIDENCE_PROFILE_EVENT_STORAGE_ACCESS,
     LOG_EVIDENCE_PROFILE_KIND, LogCategory, LogEventEnvelope, LogEvidenceProfile, LogOutcome,
     LogSeverity, MaterializationBudget, MaterializationSchemaPosture, ProjectionDeltaOp,
     ProjectionDeltaOpKind, ProjectionPathSegment, RECORD_ACCESS_EPOCH, RECORD_ACCESS_GROUP,
@@ -1658,6 +1660,10 @@ fn logging_event_fabric_access_classes(
                 LOG_EVIDENCE_PROFILE_EVENT_SERVICE_EVENT.to_string(),
                 LOG_EVIDENCE_PROFILE_EVENT_STORAGE_ACCESS.to_string(),
                 LOG_EVIDENCE_PROFILE_EVENT_MEDIA_PATH.to_string(),
+                LOG_EVIDENCE_PROFILE_EVENT_HOST_SECURITY.to_string(),
+                LOG_EVIDENCE_PROFILE_EVENT_SERVICE_HARDENING.to_string(),
+                LOG_EVIDENCE_PROFILE_EVENT_NETWORK_EXPOSURE.to_string(),
+                LOG_EVIDENCE_PROFILE_EVENT_EVIDENCE_REQUEST.to_string(),
             ],
             access_group_refs: vec![group_id.clone()],
             processor_role_refs: vec![
@@ -1865,6 +1871,10 @@ fn cybersec_evidence_profile(state: &ApiState, now: u64) -> Result<LogEvidencePr
             LOG_EVIDENCE_PROFILE_EVENT_SERVICE_EVENT.to_string(),
             LOG_EVIDENCE_PROFILE_EVENT_STORAGE_ACCESS.to_string(),
             LOG_EVIDENCE_PROFILE_EVENT_MEDIA_PATH.to_string(),
+            LOG_EVIDENCE_PROFILE_EVENT_HOST_SECURITY.to_string(),
+            LOG_EVIDENCE_PROFILE_EVENT_SERVICE_HARDENING.to_string(),
+            LOG_EVIDENCE_PROFILE_EVENT_NETWORK_EXPOSURE.to_string(),
+            LOG_EVIDENCE_PROFILE_EVENT_EVIDENCE_REQUEST.to_string(),
         ],
         retention_window: "90d".to_string(),
         safe_index_refs: vec![
@@ -3705,6 +3715,16 @@ mod tests {
                 .processor_role_refs
                 .contains(&"role:cybersec.processor".to_string())
         );
+        assert!(
+            access_class
+                .event_classes
+                .contains(&LOG_EVIDENCE_PROFILE_EVENT_SERVICE_HARDENING.to_string())
+        );
+        assert!(
+            access_class
+                .event_classes
+                .contains(&LOG_EVIDENCE_PROFILE_EVENT_NETWORK_EXPOSURE.to_string())
+        );
         assert_eq!(
             event_fabric["processorContracts"].as_array().unwrap().len(),
             2
@@ -3752,6 +3772,16 @@ mod tests {
         assert_eq!(
             cybersec_processor_contract.processor_role_ref,
             "role:cybersec.processor"
+        );
+        assert!(
+            cybersec_processor_contract
+                .input_event_classes
+                .contains(&LOG_EVIDENCE_PROFILE_EVENT_HOST_SECURITY.to_string())
+        );
+        assert!(
+            cybersec_processor_contract
+                .input_event_classes
+                .contains(&LOG_EVIDENCE_PROFILE_EVENT_EVIDENCE_REQUEST.to_string())
         );
         assert!(
             cybersec_processor_contract

--- a/src/edge_client.rs
+++ b/src/edge_client.rs
@@ -2,12 +2,14 @@
 use anyhow::{Context, Result};
 use constitute_fabric::{HostFabricMemberContributionSpec, build_host_fabric_member_contribution};
 use constitute_protocol::{
-    CAPABILITY_SWARM_EDGE_ATTACH, FABRIC_MEMBER_CONTRIBUTION_RUNNING,
-    FABRIC_MEMBER_ROLE_LOGGING_PROCESSOR, HostFabricMemberContribution, SWARM_EDGE_WIRE_ACCEPT,
-    SWARM_EDGE_WIRE_HELLO, SWARM_EDGE_WIRE_RESUME, SWARM_FRAME_VERSION, SWARM_WIRE_FRAME, SwarmAck,
-    SwarmEdgeAccept, SwarmEdgeHello, SwarmFrame, SwarmFrameBody, SwarmFrameKind, ZoneScope,
-    seal_envelope, swarm_frame_id, validate_host_fabric_member_contribution,
-    validate_swarm_edge_hello, validate_swarm_frame,
+    CAPABILITY_SWARM_EDGE_ATTACH, CARRIER_EDGE_ADAPTER_WEB_SOCKET, CARRIER_EDGE_BACKPRESSURE_CLEAR,
+    CARRIER_EDGE_SESSION_OPEN, CarrierEdgeSessionEvidence, FABRIC_MEMBER_CONTRIBUTION_RUNNING,
+    FABRIC_MEMBER_ROLE_LOGGING_PROCESSOR, HostFabricMemberContribution,
+    RECORD_CARRIER_EDGE_SESSION_EVIDENCE, SWARM_EDGE_WIRE_ACCEPT, SWARM_EDGE_WIRE_HELLO,
+    SWARM_EDGE_WIRE_RESUME, SWARM_FRAME_VERSION, SWARM_WIRE_FRAME, SwarmAck, SwarmEdgeAccept,
+    SwarmEdgeHello, SwarmFrame, SwarmFrameBody, SwarmFrameKind, ZoneScope, seal_envelope,
+    swarm_frame_id, validate_carrier_edge_session_evidence,
+    validate_host_fabric_member_contribution, validate_swarm_edge_hello, validate_swarm_frame,
 };
 use futures_util::{SinkExt, StreamExt};
 use serde::{Deserialize, Serialize};
@@ -33,6 +35,7 @@ pub struct SwarmEdgeClientConfig {
 #[derive(Clone, Debug, Default)]
 pub struct SwarmEdgeClientState {
     pub session_id: Option<String>,
+    pub carrier_edge_session_evidence: Option<CarrierEdgeSessionEvidence>,
     pub last_acked_frame_id: Option<String>,
     pub rejects: Vec<String>,
 }
@@ -151,10 +154,7 @@ fn logging_host_fabric_contribution(
             "module:logging-processor".to_string(),
             service_ref.to_string(),
         ],
-        source_refs: vec![format!(
-            "source:logging:{}",
-            config.service_pk.trim()
-        )],
+        source_refs: vec![format!("source:logging:{}", config.service_pk.trim())],
         capability_refs: LOGGING_EDGE_CAPABILITIES
             .iter()
             .map(|value| value.to_string())
@@ -385,11 +385,7 @@ pub async fn handle_gateway_text(
     };
     match message {
         GatewayWireMessage::Accept { accept } | GatewayWireMessage::Resume { accept } => {
-            tracing::info!(
-                session_id = %accept.session_id,
-                "logging attached to gateway edge stream"
-            );
-            client_state.session_id = Some(accept.session_id);
+            note_carrier_edge_accept(client_state, &accept, now)?;
             Ok(Vec::new())
         }
         GatewayWireMessage::Frame { frame } => {
@@ -456,11 +452,7 @@ async fn handle_gateway_text_for_queue(
     };
     match message {
         GatewayWireMessage::Accept { accept } | GatewayWireMessage::Resume { accept } => {
-            tracing::info!(
-                session_id = %accept.session_id,
-                "logging attached to gateway edge stream"
-            );
-            client_state.session_id = Some(accept.session_id);
+            note_carrier_edge_accept(client_state, &accept, now)?;
         }
         GatewayWireMessage::Frame { frame } => {
             admit_logging_gateway_frame(state, client_state, frame, now, frame_tx, out_tx);
@@ -512,6 +504,71 @@ fn try_send_logging_edge_response(out_tx: &mpsc::Sender<SwarmFrame>, frame: Swar
             "logging edge response queue saturated"
         );
     }
+}
+
+pub fn logging_carrier_edge_session_evidence(
+    accept: &SwarmEdgeAccept,
+    now: u64,
+) -> Result<CarrierEdgeSessionEvidence> {
+    let member_ref = accept.member_ref.trim();
+    let session_id = accept.session_id.trim();
+    let service_ref = accept
+        .promise_refs
+        .iter()
+        .map(|reference| reference.trim())
+        .find(|reference| reference.starts_with("service:"))
+        .map(ToString::to_string)
+        .unwrap_or_else(|| format!("service:logging:{member_ref}"));
+    let record = CarrierEdgeSessionEvidence {
+        kind: Some(RECORD_CARRIER_EDGE_SESSION_EVIDENCE.to_string()),
+        evidence_id: format!(
+            "carrier-edge-evidence:logging:{}:{}",
+            slug(&service_ref),
+            slug(session_id)
+        ),
+        selection_ref: format!("carrier-select:{}:gateway-edge", slug(&service_ref)),
+        edge_session_ref: format!("edge-session:{session_id}"),
+        adapter_ref: "adapter:gateway-association:websocket".to_string(),
+        adapter_kind: CARRIER_EDGE_ADAPTER_WEB_SOCKET.to_string(),
+        participant_ref: service_ref.clone(),
+        peer_ref: None,
+        state: CARRIER_EDGE_SESSION_OPEN.to_string(),
+        connection_state: Some("connected".to_string()),
+        backpressure_state: Some(CARRIER_EDGE_BACKPRESSURE_CLEAR.to_string()),
+        retry_posture: json!({ "state": "notRequired", "retryAfterMs": null }),
+        release_posture: json!({ "state": "held", "expiresAt": accept.expires_at }),
+        safe_facts: json!({
+            "service": "logging",
+            "memberKind": accept.member_kind,
+            "capabilityCount": accept.capability_refs.len(),
+            "channelCount": accept.channel_refs.len(),
+            "promiseCount": accept.promise_refs.len(),
+            "source": "swarmEdgeAccept"
+        }),
+        evidence_refs: vec![format!("session:{session_id}"), service_ref],
+        blocked_reasons: vec![],
+        observed_at: now,
+        expires_at: accept.expires_at,
+    };
+    validate_carrier_edge_session_evidence(&record)?;
+    Ok(record)
+}
+
+fn note_carrier_edge_accept(
+    client_state: &mut SwarmEdgeClientState,
+    accept: &SwarmEdgeAccept,
+    now: u64,
+) -> Result<()> {
+    let evidence = logging_carrier_edge_session_evidence(accept, now)?;
+    tracing::info!(
+        session_id = %accept.session_id,
+        adapter_ref = %evidence.adapter_ref,
+        carrier_state = %evidence.state,
+        "logging carrier edge session open"
+    );
+    client_state.session_id = Some(accept.session_id.clone());
+    client_state.carrier_edge_session_evidence = Some(evidence);
+    Ok(())
 }
 
 async fn process_gateway_work_frame(
@@ -599,6 +656,23 @@ fn handle_ack_reject(client_state: &mut SwarmEdgeClientState, frame: &SwarmFrame
 
 pub fn wire_kind(value: &Value) -> Option<&str> {
     value.get("type").and_then(Value::as_str)
+}
+
+fn slug(value: &str) -> String {
+    value
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() {
+                ch.to_ascii_lowercase()
+            } else {
+                '-'
+            }
+        })
+        .collect::<String>()
+        .split('-')
+        .filter(|segment| !segment.is_empty())
+        .collect::<Vec<_>>()
+        .join("-")
 }
 
 pub const HELLO_WIRE_KIND: &str = SWARM_EDGE_WIRE_HELLO;
@@ -857,6 +931,47 @@ mod tests {
         let wire =
             serde_json::to_value(ServiceWireMessage::Hello { hello: &hello }).expect("wire json");
         assert_eq!(wire_kind(&wire), Some(HELLO_WIRE_KIND));
+    }
+
+    #[test]
+    fn logging_edge_client_materializes_carrier_evidence_from_accept() {
+        let service_pk = pubkey_from_sk_hex(&"1".repeat(64)).expect("service pk");
+        let config = SwarmEdgeClientConfig {
+            gateway_endpoint: "ws://127.0.0.1:7000/swarm.edge".to_string(),
+            member_ref: service_pk.clone(),
+            service_pk: service_pk.clone(),
+            service_sk_hex: "1".repeat(64),
+            zone_id: "zone_lab".to_string(),
+        };
+        let hello = build_hello(&config, 1_700_000_000_000);
+        let accept = SwarmEdgeAccept {
+            session_id: "edge-logging-1".to_string(),
+            member_kind: hello.member_kind.clone(),
+            member_ref: hello.member_ref.clone(),
+            zone_scope: hello.zone_scope.clone(),
+            accepted_version: SWARM_FRAME_VERSION as u32,
+            last_acked_frame_id: None,
+            last_projection_revisions: json!({}),
+            capability_refs: hello.capability_refs.clone(),
+            channel_refs: hello.channel_refs.clone(),
+            promise_refs: hello.promise_refs.clone(),
+            nonce: "accept-logging".to_string(),
+            issued_at: 1_700_000_000_010,
+            expires_at: Some(1_700_000_060_000),
+            sealed_claims: hello.sealed_claims.clone(),
+        };
+        let evidence = logging_carrier_edge_session_evidence(&accept, 1_700_000_000_011)
+            .expect("carrier evidence");
+        validate_carrier_edge_session_evidence(&evidence).expect("valid carrier evidence");
+        assert_eq!(
+            evidence.adapter_ref,
+            "adapter:gateway-association:websocket"
+        );
+        assert_eq!(
+            evidence.participant_ref,
+            format!("service:logging:{service_pk}")
+        );
+        assert_eq!(evidence.state, CARRIER_EDGE_SESSION_OPEN);
     }
 
     #[test]

--- a/src/edge_client.rs
+++ b/src/edge_client.rs
@@ -3,12 +3,12 @@ use anyhow::{Context, Result};
 use constitute_fabric::{HostFabricMemberContributionSpec, build_host_fabric_member_contribution};
 use constitute_protocol::{
     CAPABILITY_SWARM_EDGE_ATTACH, CARRIER_EDGE_ADAPTER_WEB_SOCKET, CARRIER_EDGE_BACKPRESSURE_CLEAR,
-    CARRIER_EDGE_SESSION_OPEN, CarrierEdgeSessionEvidence, FABRIC_MEMBER_CONTRIBUTION_RUNNING,
-    FABRIC_MEMBER_ROLE_LOGGING_PROCESSOR, HostFabricMemberContribution,
-    RECORD_CARRIER_EDGE_SESSION_EVIDENCE, SWARM_EDGE_WIRE_ACCEPT, SWARM_EDGE_WIRE_HELLO,
-    SWARM_EDGE_WIRE_RESUME, SWARM_FRAME_VERSION, SWARM_WIRE_FRAME, SwarmAck, SwarmEdgeAccept,
-    SwarmEdgeHello, SwarmFrame, SwarmFrameBody, SwarmFrameKind, ZoneScope, seal_envelope,
-    swarm_frame_id, validate_carrier_edge_session_evidence,
+    CARRIER_EDGE_NETWORK_LOCAL_NETWORK, CARRIER_EDGE_SESSION_OPEN, CarrierEdgeSessionEvidence,
+    FABRIC_MEMBER_CONTRIBUTION_RUNNING, FABRIC_MEMBER_ROLE_LOGGING_PROCESSOR,
+    HostFabricMemberContribution, RECORD_CARRIER_EDGE_SESSION_EVIDENCE, SWARM_EDGE_WIRE_ACCEPT,
+    SWARM_EDGE_WIRE_HELLO, SWARM_EDGE_WIRE_RESUME, SWARM_FRAME_VERSION, SWARM_WIRE_FRAME, SwarmAck,
+    SwarmEdgeAccept, SwarmEdgeHello, SwarmFrame, SwarmFrameBody, SwarmFrameKind, ZoneScope,
+    seal_envelope, swarm_frame_id, validate_carrier_edge_session_evidence,
     validate_host_fabric_member_contribution, validate_swarm_edge_hello, validate_swarm_frame,
 };
 use futures_util::{SinkExt, StreamExt};
@@ -532,10 +532,14 @@ pub fn logging_carrier_edge_session_evidence(
         adapter_kind: CARRIER_EDGE_ADAPTER_WEB_SOCKET.to_string(),
         participant_ref: service_ref.clone(),
         peer_ref: None,
+        session_binding_ref: Some(format!("binding:gateway-edge:{session_id}")),
+        network_sensitivity: Some(CARRIER_EDGE_NETWORK_LOCAL_NETWORK.to_string()),
         state: CARRIER_EDGE_SESSION_OPEN.to_string(),
         connection_state: Some("connected".to_string()),
         backpressure_state: Some(CARRIER_EDGE_BACKPRESSURE_CLEAR.to_string()),
         retry_posture: json!({ "state": "notRequired", "retryAfterMs": null }),
+        reconnect_posture: json!({ "state": "idle", "retryAfterMs": null }),
+        close_posture: json!({ "state": "held", "reason": "" }),
         release_posture: json!({ "state": "held", "expiresAt": accept.expires_at }),
         safe_facts: json!({
             "service": "logging",
@@ -546,6 +550,8 @@ pub fn logging_carrier_edge_session_evidence(
             "source": "swarmEdgeAccept"
         }),
         evidence_refs: vec![format!("session:{session_id}"), service_ref],
+        proof_substrate_refs: vec![],
+        resource_posture_refs: vec![],
         blocked_reasons: vec![],
         observed_at: now,
         expires_at: accept.expires_at,

--- a/src/edge_client.rs
+++ b/src/edge_client.rs
@@ -1,14 +1,16 @@
 // domain-owned-vocabulary: logging.edge.reject swarm.edge.claims
 use anyhow::{Context, Result};
-use constitute_fabric::{HostFabricMemberContributionSpec, build_host_fabric_member_contribution};
+use constitute_fabric::{
+    GatewayWebSocketCarrierSessionEvidenceInput, HostFabricMemberContributionSpec,
+    build_gateway_websocket_carrier_session_evidence, build_host_fabric_member_contribution,
+};
 use constitute_protocol::{
-    CAPABILITY_SWARM_EDGE_ATTACH, CARRIER_EDGE_ADAPTER_WEB_SOCKET, CARRIER_EDGE_BACKPRESSURE_CLEAR,
-    CARRIER_EDGE_NETWORK_LOCAL_NETWORK, CARRIER_EDGE_SESSION_OPEN, CarrierEdgeSessionEvidence,
+    CAPABILITY_SWARM_EDGE_ATTACH, CARRIER_EDGE_SESSION_OPEN, CarrierEdgeSessionEvidence,
     FABRIC_MEMBER_CONTRIBUTION_RUNNING, FABRIC_MEMBER_ROLE_LOGGING_PROCESSOR,
-    HostFabricMemberContribution, RECORD_CARRIER_EDGE_SESSION_EVIDENCE, SWARM_EDGE_WIRE_ACCEPT,
-    SWARM_EDGE_WIRE_HELLO, SWARM_EDGE_WIRE_RESUME, SWARM_FRAME_VERSION, SWARM_WIRE_FRAME, SwarmAck,
-    SwarmEdgeAccept, SwarmEdgeHello, SwarmFrame, SwarmFrameBody, SwarmFrameKind, ZoneScope,
-    seal_envelope, swarm_frame_id, validate_carrier_edge_session_evidence,
+    HostFabricMemberContribution, SWARM_EDGE_WIRE_ACCEPT, SWARM_EDGE_WIRE_HELLO,
+    SWARM_EDGE_WIRE_RESUME, SWARM_FRAME_VERSION, SWARM_WIRE_FRAME, SwarmAck, SwarmEdgeAccept,
+    SwarmEdgeHello, SwarmFrame, SwarmFrameBody, SwarmFrameKind, ZoneScope, seal_envelope,
+    swarm_frame_id, validate_carrier_edge_session_evidence,
     validate_host_fabric_member_contribution, validate_swarm_edge_hello, validate_swarm_frame,
 };
 use futures_util::{SinkExt, StreamExt};
@@ -519,8 +521,7 @@ pub fn logging_carrier_edge_session_evidence(
         .find(|reference| reference.starts_with("service:"))
         .map(ToString::to_string)
         .unwrap_or_else(|| format!("service:logging:{member_ref}"));
-    let record = CarrierEdgeSessionEvidence {
-        kind: Some(RECORD_CARRIER_EDGE_SESSION_EVIDENCE.to_string()),
+    build_gateway_websocket_carrier_session_evidence(GatewayWebSocketCarrierSessionEvidenceInput {
         evidence_id: format!(
             "carrier-edge-evidence:logging:{}:{}",
             slug(&service_ref),
@@ -528,19 +529,9 @@ pub fn logging_carrier_edge_session_evidence(
         ),
         selection_ref: format!("carrier-select:{}:gateway-edge", slug(&service_ref)),
         edge_session_ref: format!("edge-session:{session_id}"),
-        adapter_ref: "adapter:gateway-association:websocket".to_string(),
-        adapter_kind: CARRIER_EDGE_ADAPTER_WEB_SOCKET.to_string(),
         participant_ref: service_ref.clone(),
         peer_ref: None,
-        session_binding_ref: Some(format!("binding:gateway-edge:{session_id}")),
-        network_sensitivity: Some(CARRIER_EDGE_NETWORK_LOCAL_NETWORK.to_string()),
-        state: CARRIER_EDGE_SESSION_OPEN.to_string(),
-        connection_state: Some("connected".to_string()),
-        backpressure_state: Some(CARRIER_EDGE_BACKPRESSURE_CLEAR.to_string()),
-        retry_posture: json!({ "state": "notRequired", "retryAfterMs": null }),
-        reconnect_posture: json!({ "state": "idle", "retryAfterMs": null }),
-        close_posture: json!({ "state": "held", "reason": "" }),
-        release_posture: json!({ "state": "held", "expiresAt": accept.expires_at }),
+        session_binding_ref: format!("binding:gateway-edge:{session_id}"),
         safe_facts: json!({
             "service": "logging",
             "memberKind": accept.member_kind,
@@ -552,12 +543,9 @@ pub fn logging_carrier_edge_session_evidence(
         evidence_refs: vec![format!("session:{session_id}"), service_ref],
         proof_substrate_refs: vec![],
         resource_posture_refs: vec![],
-        blocked_reasons: vec![],
         observed_at: now,
         expires_at: accept.expires_at,
-    };
-    validate_carrier_edge_session_evidence(&record)?;
-    Ok(record)
+    })
 }
 
 fn note_carrier_edge_accept(

--- a/src/edge_client.rs
+++ b/src/edge_client.rs
@@ -140,10 +140,21 @@ fn logging_host_fabric_contribution(
         fabric_ref,
         host_ref: zone_ref.clone(),
         member_ref: config.member_ref.clone(),
+        participant_ref: config.member_ref.clone(),
         role: FABRIC_MEMBER_ROLE_LOGGING_PROCESSOR.to_string(),
+        role_ref: format!("role:{FABRIC_MEMBER_ROLE_LOGGING_PROCESSOR}"),
         state: FABRIC_MEMBER_CONTRIBUTION_RUNNING.to_string(),
         contract_ref: service_ref.to_string(),
         subject_ref: service_ref.to_string(),
+        module_refs: vec![
+            "module:logging-edge-client".to_string(),
+            "module:logging-processor".to_string(),
+            service_ref.to_string(),
+        ],
+        source_refs: vec![format!(
+            "source:logging:{}",
+            config.service_pk.trim()
+        )],
         capability_refs: LOGGING_EDGE_CAPABILITIES
             .iter()
             .map(|value| value.to_string())

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,21 +28,13 @@ struct Args {
     swarm_zone_id: String,
 }
 
-fn configured_swarm_edge_endpoint(args: &Args) -> Option<String> {
-    args.swarm_edge_endpoint
-        .clone()
-        .or_else(|| std::env::var("CONSTITUTE_SWARM_EDGE_URL").ok())
-        .map(|value| value.trim().to_string())
-        .filter(|value| !value.is_empty())
-}
-
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let args = Args::parse();
     tracing_subscriber::fmt()
         .with_env_filter(EnvFilter::new(&args.log_level))
         .init();
-    let engine = LoggingEngine::open(&args.data_dir, args.archive_container_id.clone())?;
+    let engine = LoggingEngine::open(&args.data_dir, args.archive_container_id)?;
     let identity = LoggingServiceIdentity::load_or_create(&args.data_dir)?;
     let bind = args.bind.to_string();
     persist_hosted_service_manifest(
@@ -52,7 +44,7 @@ async fn main() -> anyhow::Result<()> {
         &identity,
         &bind,
     )?;
-    if let Some(gateway_endpoint) = configured_swarm_edge_endpoint(&args) {
+    if let Some(gateway_endpoint) = args.swarm_edge_endpoint.clone() {
         let edge_state = api::ApiState {
             engine: engine.clone(),
             storage_url: args.storage_url.clone(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,13 +28,21 @@ struct Args {
     swarm_zone_id: String,
 }
 
+fn configured_swarm_edge_endpoint(args: &Args) -> Option<String> {
+    args.swarm_edge_endpoint
+        .clone()
+        .or_else(|| std::env::var("CONSTITUTE_SWARM_EDGE_URL").ok())
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let args = Args::parse();
     tracing_subscriber::fmt()
         .with_env_filter(EnvFilter::new(&args.log_level))
         .init();
-    let engine = LoggingEngine::open(&args.data_dir, args.archive_container_id)?;
+    let engine = LoggingEngine::open(&args.data_dir, args.archive_container_id.clone())?;
     let identity = LoggingServiceIdentity::load_or_create(&args.data_dir)?;
     let bind = args.bind.to_string();
     persist_hosted_service_manifest(
@@ -44,7 +52,7 @@ async fn main() -> anyhow::Result<()> {
         &identity,
         &bind,
     )?;
-    if let Some(gateway_endpoint) = args.swarm_edge_endpoint.clone() {
+    if let Some(gateway_endpoint) = configured_swarm_edge_endpoint(&args) {
         let edge_state = api::ApiState {
             engine: engine.clone(),
             storage_url: args.storage_url.clone(),


### PR DESCRIPTION
## Summary
- Publishes the fabric-control transition branch for `constitute-logging`.
- Contributes the `event-fabric-logging` portion of the host-fabric/public coordination train.
- Keeps this repo as implementation custody while contract posture, evidence, and reducer boundaries continue to harden.

## Coordination
- Head: `0x/fabric-transition/topology-execution`
- Base: `main`
- Commit: `f20a422f7134` feat: prove routed event fabric processing

## Expected Checks
- cargo:test